### PR TITLE
Add support for allow-select option on autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
    There were a bunch of unreleased refactorings and tweaks on master that our project had yet to absorb.
    This fork reflects our divergence from the original mbenford/ngTagsInput begining with release v3.2.0
 - v3.2.1 is our first alteration: feature/autocomplete-allow-select
+    Eg, to prevent our injected hints from being selectable by the autocomplete directive:
+       autocomplete[... allow-select="$match.type !== 'hint'" ...]
 ```
 
 # ngTagsInput 


### PR DESCRIPTION
Allows for programmatic opt-out for certain items in
the suggestion list to avoid selection.  (Eg, enables
adding informative hint text as the first item in the
suggestion list, above the actual first desired
suggestion.)