### PR TITLE
Invert allow-select, replacing w prevent-select

### DIFF
--- a/src/auto-complete.js
+++ b/src/auto-complete.js
@@ -31,13 +31,12 @@
  *    The expression is provided with the current match as $match, its index as $index and its state as $selected. The result
  *    of the evaluation must be one of the values supported by the ngClass directive (either a string, an array or an object).
  *    See https://docs.angularjs.org/api/ng/directive/ngClass for more information.
- * @param {expression=} [allowSelect=NA] Expression to evaluate for each match to determine if the match can be selected 
- *    in the UI. If the expression is defined, it is provided with the current match as $match.
- *    If the expression returns true, the match will be selectable as normal. Otherwise, any attempt to select the match
- *    will result in the next selectable match being selected, or none if there are no selectable matches left in the list.
+ * @param {expression=} [preventSelect=NA] Expression to evaluate for each match to determine if the match should prevent
+ *    itself from being selected in the UI. If the expression is defined and returns true, the item will NOT be selectable.
+ *    The expression is provided with the current match as $match, and its index as $index.
  */
 tagsInput.directive('autoComplete', function($document, $timeout, $sce, $q, tagsInputConfig, tiUtil) {
-    function SuggestionList(loadFn, options, events, allowSelect) {
+    function SuggestionList(loadFn, options, events, preventSelect) {
         var self = {}, getDifference, lastPromise, getTagId;
 
         getTagId = function() {
@@ -111,7 +110,7 @@ tagsInput.directive('autoComplete', function($document, $timeout, $sce, $q, tags
             else if (index >= self.items.length) {
                 index = 0;
             }
-            while (!allowSelect({$match: self.items[index]})) {
+            while (preventSelect({$index: index, $match: self.items[index]}) === true) {
                 index++
                 if (index >= self.items.length) {
                     index = -1;
@@ -150,7 +149,7 @@ tagsInput.directive('autoComplete', function($document, $timeout, $sce, $q, tags
         scope: {
             source: '&',
             matchClass: '&',
-            allowSelect: '&'
+            preventSelect: '&'
         },
         templateUrl: 'ngTagsInput/auto-complete.html',
         controller: function($scope, $element, $attrs) {
@@ -169,7 +168,7 @@ tagsInput.directive('autoComplete', function($document, $timeout, $sce, $q, tags
                 displayProperty: [String, '']
             });
 
-            $scope.suggestionList = new SuggestionList($scope.source, $scope.options, $scope.events, $scope.allowSelect);
+            $scope.suggestionList = new SuggestionList($scope.source, $scope.options, $scope.events, $scope.preventSelect);
 
             this.registerAutocompleteMatch = function() {
                 return {


### PR DESCRIPTION
Decided "prevent-select" makes more sense than "allow-select" for likely use cases.