### PR TITLE
Provide $modifiers local to onTagAdding and onTagAdded.

### DIFF
--- a/src/auto-complete.js
+++ b/src/auto-complete.js
@@ -197,16 +197,25 @@ tagsInput.directive('autoComplete', function($document, $timeout, $sce, $q, tags
 
             scope.templateScope = tagsInput.getTemplateScope();
 
-            scope.addSuggestionByIndex = function(index) {
+            scope.addSuggestionByIndex = function(index,event) {
                 suggestionList.select(index);
-                scope.addSuggestion();
+                scope.addSuggestion(event);
             };
 
-            scope.addSuggestion = function() {
+            scope.addSuggestion = function(event) {
                 var added = false;
 
                 if (suggestionList.selected) {
-                    tagsInput.addTag(angular.copy(suggestionList.selected));
+                    var modifiers = { shiftKey: false, ctrlKey: false, altKey: false, metaKey: false };
+                    if (event) {
+                        modifiers = {
+                            shiftKey: event.shiftKey,
+                            ctrlKey: event.ctrlKey,
+                            altKey: event.altKey,
+                            metaKey: event.metaKey,
+                        }
+                    }
+                    tagsInput.addTag(angular.copy(suggestionList.selected), modifiers);
                     suggestionList.reset();
                     added = true;
                 }
@@ -250,8 +259,9 @@ tagsInput.directive('autoComplete', function($document, $timeout, $sce, $q, tags
                 .on('input-keydown', function(event) {
                     var key = event.keyCode,
                         handled = false;
+                    var keyIsASelector = key === KEYS.enter || key === KEYS.tab;
 
-                    if (tiUtil.isModifierOn(event) || hotkeys.indexOf(key) === -1) {
+                    if ((tiUtil.isModifierOn(event) && !keyIsASelector) || hotkeys.indexOf(key) === -1) {
                         return;
                     }
 
@@ -270,7 +280,7 @@ tagsInput.directive('autoComplete', function($document, $timeout, $sce, $q, tags
                             handled = true;
                         }
                         else if (key === KEYS.enter || key === KEYS.tab) {
-                            handled = scope.addSuggestion();
+                            handled = scope.addSuggestion(event);
                         }
                     }
                     else {

--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -67,7 +67,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, $window, $q, tags
             tag[options.displayProperty] = text;
         };
 
-        canAddTag = function(tag) {
+        canAddTag = function(tag,modifiers) {
             var tagText = getTagText(tag);
             var valid = tagText &&
                         tagText.length >= options.minLength &&
@@ -75,7 +75,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, $window, $q, tags
                         options.allowedTagsPattern.test(tagText) &&
                         !tiUtil.findInObjectArray(self.items, tag, options.keyProperty || options.displayProperty);
 
-            return $q.when(valid && onTagAdding({ $tag: tag })).then(tiUtil.promisifyValue);
+            return $q.when(valid && onTagAdding({ $tag: tag, $modifiers: modifiers })).then(tiUtil.promisifyValue);
         };
 
         canRemoveTag = function(tag) {
@@ -90,7 +90,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, $window, $q, tags
             return self.add(tag);
         };
 
-        self.add = function(tag) {
+        self.add = function(tag, modifiers) {
             var tagText = getTagText(tag);
 
             if (options.replaceSpacesWithDashes) {
@@ -99,10 +99,10 @@ tagsInput.directive('tagsInput', function($timeout, $document, $window, $q, tags
 
             setTagText(tag, tagText);
 
-            return canAddTag(tag)
+            return canAddTag(tag,modifiers)
                 .then(function() {
                     self.items.push(tag);
-                    events.trigger('tag-added', { $tag: tag });
+                    events.trigger('tag-added', { $tag: tag, $modifiers: modifiers });
                 })
                 .catch(function() {
                     if (tagText) {
@@ -220,8 +220,8 @@ tagsInput.directive('tagsInput', function($timeout, $document, $window, $q, tags
                 var input = $element.find('input');
 
                 return {
-                    addTag: function(tag) {
-                        return $scope.tagList.add(tag);
+                    addTag: function(tag,modifiers) {
+                        return $scope.tagList.add(tag, modifiers);
                     },
                     getTags: function() {
                         return $scope.tagList.items;

--- a/templates/auto-complete.html
+++ b/templates/auto-complete.html
@@ -3,7 +3,7 @@
     <li class="suggestion-item"
         ng-repeat="item in suggestionList.items track by track(item)"
         ng-class="getSuggestionClass(item, $index)"
-        ng-click="addSuggestionByIndex($index)"
+        ng-click="addSuggestionByIndex($index,$event)"
         ng-mouseenter="suggestionList.select($index)">
       <ti-autocomplete-match scope="templateScope" data="::item" selected="getSelected(item)"></ti-autocomplete-match>
     </li>


### PR DESCRIPTION
Users of ng-tags-input can now read keyboard $modifiers in
the expressions for on-tag-adding and on-tag-added event
handlers.  $modifiers is an object with boolean values set for
these keys: shiftKey, ctrlKey, altKey, metaKey.

$modifiers will be sent along for all the different ways in
which the user "selected" a suggestion from the autocomplete
list: Hitting "Enter", or "Tab", or mouse click.