### PR TITLE
Add support for autocomplete 'messages'.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,6 +30,7 @@ module.exports = function(grunt) {
                     'src/tag-item.js',
                     'src/auto-complete.js',
                     'src/auto-complete-match.js',
+                    'src/auto-complete-message.js',
                     'src/transclude-append.js',
                     'src/autosize.js',
                     'src/bind-attrs.js',

--- a/src/auto-complete-message.js
+++ b/src/auto-complete-message.js
@@ -1,0 +1,30 @@
+'use strict';
+
+/**
+ * @ngdoc directive
+ * @name tiAutocompleteMessage
+ * @module ngTagsInput
+ *
+ * @description
+ * Represents an autocomplete "message". Used internally by the autoComplete directive.
+ * (Allows for arbitrary content injection at the head of the suggestions list.)
+ */
+tagsInput.directive('tiAutocompleteMessage', function($sce, tiUtil) {
+    return {
+        restrict: 'E',
+        require: '^autoComplete',
+        template: '<ng-include src="$$template"></ng-include>',
+        scope: {
+            $scope: '=scope',
+            data: '=',
+            selected: '<'
+        },
+        link: function(scope, element, attrs, autoCompleteCtrl) {
+            var autoComplete = autoCompleteCtrl.registerAutocompleteMatch(),
+                options = autoComplete.getOptions();
+
+            scope.$$template = options.messageTemplate;
+            scope.$index = scope.$parent.$index;
+        }
+    };
+});

--- a/src/auto-complete.js
+++ b/src/auto-complete.js
@@ -11,6 +11,7 @@
  * @param {expression} source Expression to evaluate upon changing the input content. The input value is available as
  *    $query. The result of the expression must be a promise that eventually resolves to an array of strings.
  * @param {string=} [template=NA] URL or id of a custom template for rendering each element of the autocomplete list.
+ * @param {string=} [messageTemplate=NA] URL or id of a custom template for rendering each message in the bound `messages` list.
  * @param {string=} [displayProperty=tagsInput.displayText] Property to be rendered as the autocomplete label.
  * @param {number=} [debounceDelay=100] Amount of time, in milliseconds, to wait before evaluating the expression in
  *    the source option after the last keystroke.
@@ -147,6 +148,7 @@ tagsInput.directive('autoComplete', function($document, $timeout, $sce, $q, tags
         restrict: 'E',
         require: '^tagsInput',
         scope: {
+            messages: '=',
             source: '&',
             matchClass: '&',
             preventSelect: '&'
@@ -157,6 +159,7 @@ tagsInput.directive('autoComplete', function($document, $timeout, $sce, $q, tags
 
             tagsInputConfig.load('autoComplete', $scope, $attrs, {
                 template: [String, 'ngTagsInput/auto-complete-match.html'],
+                messageTemplate: [String,'ngTagsInput/auto-complete-match.html'],
                 debounceDelay: [Number, 100],
                 minLength: [Number, 3],
                 highlightMatchedText: [Boolean, true],
@@ -299,6 +302,12 @@ tagsInput.directive('autoComplete', function($document, $timeout, $sce, $q, tags
 
             events.on('suggestion-selected', function(index) {
                 scrollToElement(element, index);
+            });
+
+            scope.$watch('messages', function(value) {
+                if (value && value.length) {
+                    suggestionList.show()
+                }
             });
         }
     };

--- a/templates/auto-complete.html
+++ b/templates/auto-complete.html
@@ -1,6 +1,10 @@
 <div class="autocomplete" ng-if="suggestionList.visible">
   <ul class="suggestion-list">
     <li class="suggestion-item"
+        ng-repeat="message in messages track by track(message)">
+      <ti-autocomplete-message scope="templateScope" data="::message"></ti-autocomplete-message>
+    </li>
+    <li class="suggestion-item"
         ng-repeat="item in suggestionList.items track by track(item)"
         ng-class="getSuggestionClass(item, $index)"
         ng-click="addSuggestionByIndex($index,$event)"


### PR DESCRIPTION
The auto-complete directive now supports:
- 'messages': An array of suggestion-item-like objects to
   be rendereed at the head of the completion match list.
- 'message-template': The templateUrl value for rendering
  each message in 'messages'

(Added for Mastermind hints and loading indicator)